### PR TITLE
typescript index now exports by default and changed the function name

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,5 +25,5 @@ declare module 'mongoose-schema-to-graphql' {
         fields?: ObjectKeyStringValueAnyType,
     };
 
-  export function mainFunction(config: ConfigurationObject): any;
+    export default function createType(config: ConfigurationObject): any;
 }


### PR DESCRIPTION
trying to export the createType function in typescript resulted in "no default export", then when the code was compiled to ES5 and it tried to access the "mainFunction" from the JS files in node_modules, it didn't existed.